### PR TITLE
Improve `staircase_origami` and `normal_form`

### DIFF
--- a/experimental/Origami/src/canonical.jl
+++ b/experimental/Origami/src/canonical.jl
@@ -1,3 +1,13 @@
+# HACK HACK HACK special case optimization...
+function GAP.GapObj(obj::Vector{Int}; recursive::Bool = false)
+    len = length(obj)
+    ret_val = GAP.NewPlist(len)
+    for i = 1:len
+        ret_val[i] = obj[i]
+    end
+    return ret_val
+end
+
 function normal_form(o::Origami)
     x = horizontal_perm(o)
     y = vertical_perm(o)

--- a/experimental/Origami/src/canonical.jl
+++ b/experimental/Origami/src/canonical.jl
@@ -10,11 +10,11 @@ function normal_form(o::Origami)
 
     # Find points which minimize the lengths of the cycles in which they occur.
     # This can greatly reduce the number of breadths-first searches below.
-    minimal_cycle_lengths = [n, n]
-    minimize_cycle_lengths = []
+    minimal_cycle_lengths = (n, n)
+    minimize_cycle_lengths = Int[]
     degree_list = collect(1:n)
     for i in degree_list
-        cycle_lengths = [cycle_length(x, i), cycle_length(y, i)]
+        cycle_lengths = (cycle_length(x, i), cycle_length(y, i))
         if cycle_lengths == minimal_cycle_lengths
             push!(minimize_cycle_lengths, i)
         elseif cycle_lengths < minimal_cycle_lengths

--- a/experimental/Origami/src/canonical.jl
+++ b/experimental/Origami/src/canonical.jl
@@ -27,7 +27,8 @@ function normal_form(o::Origami)
         if cycle_lengths == minimal_cycle_lengths
             push!(minimize_cycle_lengths, i)
         elseif cycle_lengths < minimal_cycle_lengths
-            minimize_cycle_lengths = [i]
+            empty!(minimize_cycle_lengths)
+            push!(minimize_cycle_lengths, i)
             minimal_cycle_lengths = cycle_lengths
         end
     end
@@ -35,29 +36,28 @@ function normal_form(o::Origami)
     G = PermGroupElem[]
     sym = symmetric_group(n)
 
-    # TODO this can be completetly refactored. this is the exact same as
+    # TODO this can be completely refactored. this is the exact same as
     # normalform_conjugators apart from looping over different lists
+    L = fill(0, n)
+    Q = Int[]
     for i in minimize_cycle_lengths
-        L = fill(0, n)
-        seen = fill(false, n)
-        Q = [i]
-        seen[i] = true
+        fill!(L, 0)
+        empty!(Q)
+        push!(Q, i)
         numSeen = 1
         L[i] = 1
         while numSeen < n
             v = popfirst!(Q)
             wx = v^x
             wy = v^y
-            if !seen[wx]
+            if L[wx] == 0
                 push!(Q, wx)
-                seen[wx] = true
-                numSeen = numSeen + 1
+                numSeen += 1
                 L[wx] = numSeen
             end
-            if !seen[wy]
+            if L[wy] == 0
                 push!(Q, wy)
-                seen[wy] = true
-                numSeen = numSeen + 1
+                numSeen += 1
                 L[wy] = numSeen
             end
         end

--- a/experimental/Origami/src/canonical.jl
+++ b/experimental/Origami/src/canonical.jl
@@ -5,7 +5,7 @@ function normal_form(o::Origami)
 
     # TODO does this exists already? if not move to appropriate part of Oscar
     function cycle_length(sigma::PermGroupElem, i::Integer)
-        return GAP.Globals.CycleLength(GapObj(sigma), i)
+        return GAP.Globals.CycleLength(GapObj(sigma), i)::Int
     end
 
     # Find points which minimize the lengths of the cycles in which they occur.

--- a/experimental/Origami/src/canonical.jl
+++ b/experimental/Origami/src/canonical.jl
@@ -15,7 +15,7 @@ function normal_form(o::Origami)
 
     # TODO does this exists already? if not move to appropriate part of Oscar
     function cycle_length(sigma::PermGroupElem, i::Integer)
-        return GAP.Globals.CycleLength(GapObj(sigma), i)::Int
+        return GAPWrap.CYCLE_LENGTH_PERM_INT(GapObj(sigma), i)
     end
 
     # Find points which minimize the lengths of the cycles in which they occur.

--- a/experimental/Origami/src/canonical.jl
+++ b/experimental/Origami/src/canonical.jl
@@ -12,8 +12,7 @@ function normal_form(o::Origami)
     # This can greatly reduce the number of breadths-first searches below.
     minimal_cycle_lengths = (n, n)
     minimize_cycle_lengths = Int[]
-    degree_list = collect(1:n)
-    for i in degree_list
+    for i in 1:n
         cycle_lengths = (cycle_length(x, i), cycle_length(y, i))
         if cycle_lengths == minimal_cycle_lengths
             push!(minimize_cycle_lengths, i)
@@ -23,7 +22,8 @@ function normal_form(o::Origami)
         end
     end
 
-    G = []
+    G = PermGroupElem[]
+    sym = symmetric_group(n)
 
     # TODO this can be completetly refactored. this is the exact same as
     # normalform_conjugators apart from looping over different lists
@@ -51,12 +51,12 @@ function normal_form(o::Origami)
                 L[wy] = numSeen
             end
         end
-        push!(G, L)
+        push!(G, perm(sym, L))
     end
     
-    G = perm.(G)
-    G = (i -> [i^-1 * x * i, i^-1 * y * i]).(G)
+    G2 = [ (x ^ i, y ^ i) for i in G ]
     # no need to check if surface connected
-    min_entry = minimum(G)
+    min_entry = minimum(G2)
     return origami_disconnected(min_entry[1], min_entry[2], n)
+
 end

--- a/experimental/Origami/src/special_origigami.jl
+++ b/experimental/Origami/src/special_origigami.jl
@@ -12,25 +12,26 @@ end
 function staircase_origami(length::Integer, height::Integer, steps::Integer)
     h = @perm ()
     v = @perm ()
-    steps_list = collect(1:(steps - 1))
     sum_l_h = length + height
-    for step in steps_list
+    G = symmetric_group(steps * sum_l_h)
+
+    for step in 1:(steps - 1)
         h_start = (step - 1) * (sum_l_h) + 1
         h_end = (step - 1) * (sum_l_h) + length
-        h = h * cperm(h_start:h_end)
+        h = h * cperm(G, h_start:h_end)
 
         v_start = step * length + (step - 1) * height
         v_end = step * (sum_l_h) + 1
-        v = v * cperm(v_start:v_end)
+        v = v * cperm(G, v_start:v_end)
     end
 
     h_start = (steps - 1) * (sum_l_h) + 1
     h_end = (steps - 1) * (sum_l_h) + length
-    h = h * cperm(h_start:h_end)
+    h = h * cperm(G, h_start:h_end)
 
     v_start = steps * length + (steps - 1) * height
     v_end = steps * sum_l_h
-    v = v * cperm(v_start:v_end)
+    v = v * cperm(G, v_start:v_end)
 
     return normal_form(origami(h, v))
 end

--- a/experimental/Origami/src/types.jl
+++ b/experimental/Origami/src/types.jl
@@ -1,4 +1,4 @@
-mutable struct Origami
+struct Origami
     o::GapObj
     h::PermGroupElem
     v::PermGroupElem

--- a/experimental/Origami/src/types.jl
+++ b/experimental/Origami/src/types.jl
@@ -2,5 +2,5 @@ mutable struct Origami
     o::GapObj
     h::PermGroupElem
     v::PermGroupElem
-    d::Oscar.Integer
+    d::Int
 end

--- a/src/GAP/wrappers.jl
+++ b/src/GAP/wrappers.jl
@@ -50,7 +50,9 @@ GAP.@wrap CollectionsFamily(x::GapObj)::GapObj
 GAP.@wrap Conductor(x::Any)::GapInt
 GAP.@wrap ConjugacyClasses(x::GapObj)::GapObj
 GAP.@wrap CycleFromList(x::GapObj)::GapObj
+GAP.@wrap CycleLength(x::GapObj, y::Int)::GapInt
 GAP.@wrap CycleStructurePerm(x::GapObj)::GapObj
+GAP.@wrap CYCLE_LENGTH_PERM_INT(x::GapObj, y::Int)::Int
 GAP.@wrap CycList(x::GapObj)::GapInt
 GAP.@wrap CyclotomicPol(x::Int)::GapObj
 GAP.@wrap DecomposeTensorProduct(x::GapObj, y::GapObj, z::GapObj)::GapObj


### PR DESCRIPTION
Here are some timings in Julia 1.9, with an M1 MacBook Pro.

First let's get base numbers: your `origami` branch, plus GAP.jl 0.10.0 (the version current when you first contacted me about this). Measurements done using the `BenchmarkTools` package to reduce effects of e.g. the first-time-run overhead caused by compilations, randomization etc. I used three different parameter sets, and we'll reuse those with later measurements.
```
julia> @benchmark GAP.Globals.StaircaseOrigami(100, 100, 100)
BenchmarkTools.Trial: 9 samples with 1 evaluation.
 Range (min … max):  558.704 ms … 579.174 ms  ┊ GC (min … max): 2.23% … 5.29%
 Time  (median):     565.411 ms               ┊ GC (median):    2.40%
 Time  (mean ± σ):   567.037 ms ±   7.066 ms  ┊ GC (mean ± σ):  3.02% ± 1.26%

  █      █ █     █   █     █   █                         █    █
  █▁▁▁▁▁▁█▁█▁▁▁▁▁█▁▁▁█▁▁▁▁▁█▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▁▁█ ▁
  559 ms           Histogram: frequency by time          579 ms <

 Memory estimate: 251.30 MiB, allocs estimate: 4126869.

julia> @benchmark GAP.Globals.StaircaseOrigami(100, 200, 200)
BenchmarkTools.Trial: 2 samples with 1 evaluation.
 Range (min … max):  3.657 s …  3.661 s  ┊ GC (min … max): 2.86% … 2.72%
 Time  (median):     3.659 s             ┊ GC (median):    2.79%
 Time  (mean ± σ):   3.659 s ± 2.572 ms  ┊ GC (mean ± σ):  2.79% ± 0.10%

  █                                                      █
  █▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█ ▁
  3.66 s        Histogram: frequency by time        3.66 s <

 Memory estimate: 1.45 GiB, allocs estimate: 24373793.

julia> @benchmark GAP.Globals.StaircaseOrigami(200, 200, 200)
BenchmarkTools.Trial: 1 sample with 1 evaluation.
 Single result which took 5.211 s (2.59% GC) to evaluate,
 with a memory estimate of 2.14 GiB, over 32494000 allocations.

```


Let's compare that to the initial version of your Julia code, with GAP.jl 0.10.0. Since it is slooow, I'll only include the results for `(100,100,100)`
```
julia> @benchmark Oscar.staircase_origami(100, 100, 100)
BenchmarkTools.Trial: 3 samples with 1 evaluation.
 Range (min … max):  2.225 s …   2.248 s  ┊ GC (min … max): 4.46% … 4.05%
 Time  (median):     2.241 s              ┊ GC (median):    4.31%
 Time  (mean ± σ):   2.238 s ± 11.602 ms  ┊ GC (mean ± σ):  4.27% ± 0.21%

  █                                        █              █
  █▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁█ ▁
  2.23 s         Histogram: frequency by time        2.25 s <

 Memory estimate: 1.45 GiB, allocs estimate: 53886970.
```
Note that this allocates 1.45 GB (in 53 million allocations) while the GAP version only allocates 0.25 MB (in 4.1 million allocations), a first hint. 


We can use the Profile to see what is going on (I am abbreviating the output):
```
julia> using Profile

julia> @profile Oscar.staircase_origami(100, 100, 100);
julia> Profile.print()
Overhead ╎ [+additional indent] Count File:Line; Function
=========================================================
 12╎12   @Base/array.jl:1461; popfirst!(a::Vector{Int64})
   ╎7    @Base/array.jl:1061; push!(a::Vector{Int64}, item::Int64)
  7╎ 7    @Base/array.jl:1014; _growend!
   ╎1062 @Base/client.jl:522; _start()
[...]
112╎    ╎    ╎   1059 ...gami/src/special_origigami.jl:35; staircase_origami(length::Int64, height::Int64...
  1╎    ╎    ╎    1    ...ntal/Origami/src/canonical.jl:0; normal_form(o::Oscar.Origami)
  3╎    ╎    ╎    14   ...ntal/Origami/src/canonical.jl:17; normal_form(o::Oscar.Origami)
  1╎    ╎    ╎     11   ...ntal/Origami/src/canonical.jl:8; (::Oscar.var"#cycle_length#6280")(sigma::Perm...
   ╎    ╎    ╎    ╎ 10   @GAP/src/ccalls.jl:297; (::GapObj)(a1::GapObj, a2::Int64)
  5╎    ╎    ╎    ╎  10   @GAP/src/ccalls.jl:284; call_gap_func_nokw(::GapObj, ::GapObj, ::Va...
  5╎    ╎    ╎    ╎   5    @GAP/src/ccalls.jl:332; _call_gap_func(func::GapObj, a1::GapObj, a...
 11╎    ╎    ╎    11   ...ntal/Origami/src/canonical.jl:37; normal_form(o::Oscar.Origami)
 29╎    ╎    ╎    35   ...ntal/Origami/src/canonical.jl:38; normal_form(o::Oscar.Origami)
   ╎    ╎    ╎     4    @Base/array.jl:1466; popfirst!(a::Vector{Int64})
  4╎    ╎    ╎    ╎ 4    @Base/array.jl:1021; _deletebeg!
  2╎    ╎    ╎     2    @Base/array.jl:1467; popfirst!(a::Vector{Int64})
105╎    ╎    ╎    218  ...ntal/Origami/src/canonical.jl:39; normal_form(o::Oscar.Origami)
  2╎    ╎    ╎     113  @Oscar/src/Groups/perm.jl:353; ^(n::Int64, x::PermGroupElem)
   ╎    ╎    ╎    ╎ 111  @GAP/src/adapter.jl:396; ^
   ╎    ╎    ╎    ╎  111  @GAP/src/wrappers.jl:371; POW
  3╎    ╎    ╎    ╎   111  @GAP/src/ccalls.jl:297; GapObj
 36╎    ╎    ╎    ╎    36   @GAP/src/ccalls.jl:282; call_gap_func_nokw(::GapObj, ::Int64, ::Va...
 69╎    ╎    ╎    ╎    70   @GAP/src/ccalls.jl:284; call_gap_func_nokw(::GapObj, ::Int64, ::Va...
   ╎    ╎    ╎    ╎     1    @GAP/src/ccalls.jl:332; _call_gap_func(func::GapObj, a1::Int64, a...
  1╎    ╎    ╎    ╎    ╎ 1    @GAP/src/ccalls.jl:0; _JULIA_TO_GAP
  2╎    ╎    ╎    ╎    2    @GAP/src/ccalls.jl:288; call_gap_func_nokw(::GapObj, ::Int64, ::Va...
114╎    ╎    ╎    243  ...ntal/Origami/src/canonical.jl:40; normal_form(o::Oscar.Origami)
  1╎    ╎    ╎     129  @Oscar/src/Groups/perm.jl:353; ^(n::Int64, x::PermGroupElem)
   ╎    ╎    ╎    ╎ 128  @GAP/src/adapter.jl:396; ^
   ╎    ╎    ╎    ╎  128  @GAP/src/wrappers.jl:371; POW
 14╎    ╎    ╎    ╎   128  @GAP/src/ccalls.jl:297; GapObj
[...]
   ╎    ╎    ╎    ╎    ╎    357  @Oscar/src/Groups/perm.jl:126; perm(L::Vector{Int64})
   ╎    ╎    ╎    ╎    ╎     357  @GAP/src/constructors.jl:7; GapObj
   ╎    ╎    ╎    ╎    ╎    ╎ 357  @GAP/src/constructors.jl:7; #GapObj#49
 62╎    ╎    ╎    ╎    ╎    ╎  357  @GAP/src/julia_to_gap.jl:113; julia_to_gap
   ╎    ╎    ╎    ╎    ╎    ╎   8    @GAP/src/julia_to_gap.jl:124; julia_to_gap(obj::Vector{Int64}, rec...
```
Looking at this reveals a rather large amount of samples spent in the GAP kernel function `POW` (128 + 111 = 239 out of 1062), that's a lot for a function that is supposed to be fast. Actually it's in the call to the function...

At which point it hit me: didn't I optimize that recently? Yup, I did, but I forgot to release it. So GAP 0.10.1 was born....

Let's switch to that:
```
julia> @benchmark Oscar.staircase_origami(100, 100, 100)
BenchmarkTools.Trial: 6 samples with 1 evaluation.
 Range (min … max):  823.039 ms … 845.700 ms  ┊ GC (min … max): 5.04% … 6.80%
 Time  (median):     837.775 ms               ┊ GC (median):    6.59%
 Time  (mean ± σ):   836.143 ms ±   8.056 ms  ┊ GC (mean ± σ):  6.41% ± 0.92%

  █                    █                █ █        █          █
  █▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁█▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁█ ▁
  823 ms           Histogram: frequency by time          846 ms <

 Memory estimate: 939.14 MiB, allocs estimate: 23911714.
```
That's a lot faster (it was 2.241 s and 1.45 GB / 53 mio allocs). But still slower than plain GAP.

Another 357 samples in the original report are spent in converting a `Vector{Int}` into a GAP list of integers; again that's too much. Again it's a known issue (this one known for far too long...). We really need a proper fix, but that may take time; so I'll make GAP 0.10.2 soon with a workaround. But for now, you can copy&paste this into a Julia sessions to get the faster conversion:
```julia
# HACK HACK HACK special case optimization...
function GAP.GapObj(obj::Vector{Int}; recursive::Bool = false)
    len = length(obj)
    ret_val = GAP.NewPlist(len)
    for i = 1:len
        ret_val[i] = obj[i]
    end
    return ret_val
end
```
Let's re-run the benchmark with that:
```
julia> @benchmark Oscar.staircase_origami(100, 100, 100)
BenchmarkTools.Trial: 7 samples with 1 evaluation.
 Range (min … max):  744.316 ms … 751.337 ms  ┊ GC (min … max): 4.97% … 6.27%
 Time  (median):     750.282 ms               ┊ GC (median):    5.71%
 Time  (mean ± σ):   748.348 ms ±   3.104 ms  ┊ GC (mean ± σ):  5.70% ± 0.41%

  █                    ▁                             █      ▁ ▁
  █▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁█▁█ ▁
  744 ms           Histogram: frequency by time          751 ms <

 Memory estimate: 684.99 MiB, allocs estimate: 16012614.
```
Again: better, but still slower than GAP. Let's look at a fresh profile:
```
julia> using Profile; @profile Oscar.staircase_origami(100, 100, 100);

julia> Profile.print()
julia> Profile.print()
Overhead ╎ [+additional indent] Count File:Line; Function
=========================================================
  2╎2   @Base/array.jl:1461; popfirst!(a::Vector{Int64})
   ╎266 @Base/client.jl:522; _start()
   ╎ 266 @Base/client.jl:322; exec_options(opts::Base.JLOptions)
   ╎  266 @Base/client.jl:405; run_main_repl(interactive::Bool, quiet::Bool, banner...
[...]
 97╎    ╎    ╎   263 ...igami/src/special_origigami.jl:35; staircase_origami(length::Int64, height::Int64...
```
So out of 266 samples, 263 are spent inside `special_origigami.jl:35` which is the call to `normal_form`. Nothing else stands out specifically. So for the moment, I'll move on from the profiler, and look at the code of `normal_form`. I immediately see various issues, but let's do it systematic and ask Julia what's wrong.

A good tool to see if code is type stable is `@code_warntype`. It is best use in a terminal were it outputs with helpful colors. This is a static analysis, so I can use any input origami, it doesn't matter which
```
julia> @code_warntype normal_form(random_origami(5))
MethodInstance for AbstractAlgebra.Generic.normal_form(::Oscar.Origami)
  from normal_form(o::Oscar.Origami) @ Oscar ~/Projekte/OSCAR/Oscar.spielwiese/experimental/Origami/src/canonical.jl:1
Arguments
  #self#::Core.Const(AbstractAlgebra.Generic.normal_form)
  o::Oscar.Origami
Locals
  #6279::Oscar.var"#6279#6281"{PermGroupElem, PermGroupElem}
  @_4::Union{Nothing, Tuple{Any, Int64}}
  @_5::Any
  min_entry::Vector{PermGroupElem}
  G::Union{Vector{Any}, Vector{Vector{PermGroupElem}}, Vector{PermGroupElem}}
  degree_list::Any
  minimize_cycle_lengths::Vector
  minimal_cycle_lengths::Any
  cycle_length::Oscar.var"#cycle_length#6280"
  n::Integer
  y::PermGroupElem
  x::PermGroupElem
  i@_15::Any
  cycle_lengths::Any
  numSeen::Int64
  Q::Vector
  seen::Vector{Bool}
  L::Vector{Int64}
  i@_21::Any
  wy::Any
  wx::Any
  v::Any
[...]
```
This already tells me a lot; here a color screenshot for some more clarity:
<img width="647" alt="Screen Shot 2024-01-04 at 11 50 51" src="https://github.com/AG-Weitze-Schmithusen/Oscar.jl/assets/241512/1b9f64e3-6315-43cd-b015-1ba06eda8ba7">


Note the red variables, e.g. `n::Integer`: this tells us that the compiler was only able to infer that `n` is some integer type, but not which. But in reality, `n` will always be an `Int` -- the compiler just can't prove it, and hence anytime you write, say `n+1`, instead of emitting a single machine code instruction to increment `n`, it must do a method dispatch to find out during runtime which function to call to perform the addition, then call that function... That's a lot more work.

There are more variables where it can't infer anything or not enough. E.g. `G` is always a vector, but of three different types.

So let's do something about that. The first commit in this PR tells the compiler that `cycle_length` always returns an `Int, the second changes the type of `d` inside the `Origami` struct from `Integer` to `Int`, so that the compiler can use that information (I recommend you look at each commit in this PR separately, I usually also wrote some more explanations in the commit message).

After restarting Julia (Revise can't deal with the changed struct definition), and remember to again past the HACK for the faster conversion from `Vector{Int}` into a `GapObj`, we can run `@code_warntype` from above again now e.g. `n` is correctly inferred to be an `Int`. But others are still "red": `wx`, `wy`, `v` all are just `Any` because `Q` is; and `Q` is because `i` is. And why `i`? Because you use it to iterate over `minimize_cycle_lengths` and that starts out as a `Vector{Any}` (because you set it to `[]`, and so `i` could be `Any` ... To fix this, initialize `minimize_cycle_lengths = Int[]`.

But actually, we can do better: The third commit changes `minimal_cycle_lengths` to be a `Tuple{Int,Int}` instead of a `Vector{Int}`. That has the added advantage of avoiding allocations and enables further optimizations (essentially the compiler can stores the tuple in two registers, if it deems it sensible; it can't do that for a variable length vector). With that change, all the "red" in the output of `@code_warntype` vanishes. Let's run the benchmark again:
```
julia> @benchmark Oscar.staircase_origami(100, 100, 100)
BenchmarkTools.Trial: 13 samples with 1 evaluation.
 Range (min … max):  382.858 ms … 401.548 ms  ┊ GC (min … max): 4.09% … 8.39%
 Time  (median):     392.776 ms               ┊ GC (median):    6.54%
 Time  (mean ± σ):   392.315 ms ±   4.717 ms  ┊ GC (mean ± σ):  6.59% ± 1.14%

  ▁               █   ▁      █    ▁  ▁   █  ▁▁                ▁
  █▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▁█▁▁▁▁▁▁█▁▁▁▁█▁▁█▁▁▁█▁▁██▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█ ▁
  383 ms           Histogram: frequency by time          402 ms <

 Memory estimate: 439.97 MiB, allocs estimate: 4095265.

```
We did it, we are faster than the original GAP code and even use few allocations (but still allocate about twice as much total memory).

Well, there is still some "yellow" (things for which the compiler could narrow down the type but not nail it down). Let's fix those and while at it, avoid some more allocations (details in the commit messages). So with the top commit of this PR, we finally get:
```
julia> @benchmark Oscar.staircase_origami(100, 100, 100)
BenchmarkTools.Trial: 18 samples with 1 evaluation.
 Range (min … max):  279.488 ms … 293.132 ms  ┊ GC (min … max): 0.00% … 4.59%
 Time  (median):     287.252 ms               ┊ GC (median):    3.59%
 Time  (mean ± σ):   287.253 ms ±   3.127 ms  ┊ GC (mean ± σ):  3.45% ± 0.97%

  ▁                 ▁  ▁▁    ▁  ▁  █▁▁▁ ▁  ▁  ▁ ▁▁   ▁        ▁
  █▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁██▁▁▁▁█▁▁█▁▁████▁█▁▁█▁▁█▁██▁▁▁█▁▁▁▁▁▁▁▁█ ▁
  279 ms           Histogram: frequency by time          293 ms <

 Memory estimate: 197.10 MiB, allocs estimate: 4044278.
```
That's about twice as fast as the GAP version, and uses less memory, too.

This extends to larger inputs, too:
```
julia> @benchmark Oscar.staircase_origami(100, 200, 200)
BenchmarkTools.Trial: 4 samples with 1 evaluation.
 Range (min … max):  1.512 s …   1.540 s  ┊ GC (min … max): 2.73% … 4.08%
 Time  (median):     1.535 s              ┊ GC (median):    3.05%
 Time  (mean ± σ):   1.531 s ± 12.782 ms  ┊ GC (mean ± σ):  3.23% ± 0.65%

  █                                          █      █     █
  █▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁█▁▁▁▁▁█ ▁
  1.51 s         Histogram: frequency by time        1.54 s <

 Memory estimate: 1.13 GiB, allocs estimate: 24229191.

julia> @benchmark Oscar.staircase_origami(200, 200, 200)
BenchmarkTools.Trial: 3 samples with 1 evaluation.
 Range (min … max):  2.021 s …   2.048 s  ┊ GC (min … max): 2.62% … 2.98%
 Time  (median):     2.023 s              ┊ GC (median):    2.62%
 Time  (mean ± σ):   2.031 s ± 14.826 ms  ┊ GC (mean ± σ):  2.70% ± 0.26%

  █   █                                                   █
  █▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█ ▁
  2.02 s         Histogram: frequency by time        2.05 s <

 Memory estimate: 1.62 GiB, allocs estimate: 32369197.
```


There are more optimizations possible, but that's it for this PR... but as a teaser, I am experimenting with a patch for `int^perm` which is quite promising (it cuts down on the number of allocations tremendously and results in another great speedup):
```
julia> @benchmark Oscar.staircase_origami(100, 100, 100)
BenchmarkTools.Trial: 25 samples with 1 evaluation.
 Range (min … max):  189.703 ms … 239.392 ms  ┊ GC (min … max): 0.00% … 19.32%
 Time  (median):     203.586 ms               ┊ GC (median):    5.56%
 Time  (mean ± σ):   205.698 ms ±  14.153 ms  ┊ GC (mean ± σ):  6.35% ±  5.95%

     █▁           ▁▁       ▁                                  ▁
  ▆▆▁██▆▁▁▁▁▁▁▁▁▁▆██▆▆▆▁▁▁▁█▁▁▁▆▁▆▁▁▁▁▁▁▆▁▁▁▁▁▁▁▆▁▁▁▁▁▁▁▁▁▁▁▁▁█ ▁
  190 ms           Histogram: frequency by time          239 ms <

 Memory estimate: 137.63 MiB, allocs estimate: 146478.

julia> @benchmark Oscar.staircase_origami(100, 200, 200)
BenchmarkTools.Trial: 5 samples with 1 evaluation.
 Range (min … max):  1.080 s …  1.100 s  ┊ GC (min … max): 1.51% … 2.01%
 Time  (median):     1.088 s             ┊ GC (median):    2.06%
 Time  (mean ± σ):   1.089 s ± 8.276 ms  ┊ GC (mean ± σ):  2.04% ± 0.34%

  █       █             █              █                 █
  █▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█ ▁
  1.08 s        Histogram: frequency by time         1.1 s <

 Memory estimate: 794.77 MiB, allocs estimate: 433591.

julia> @benchmark Oscar.staircase_origami(200, 200, 200)
BenchmarkTools.Trial: 4 samples with 1 evaluation.
 Range (min … max):  1.366 s …   1.421 s  ┊ GC (min … max): 1.22% … 1.96%
 Time  (median):     1.375 s              ┊ GC (median):    1.23%
 Time  (mean ± σ):   1.384 s ± 25.098 ms  ┊ GC (mean ± σ):  1.40% ± 0.38%

  █    █       █                                          █
  █▁▁▁▁█▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█ ▁
  1.37 s         Histogram: frequency by time        1.42 s <

 Memory estimate: 1.14 GiB, allocs estimate: 573597.
```
