### PR TITLE
Load gap packages from artifacts

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -7,18 +7,18 @@ lazy = true
     url = "https://zenodo.org/records/15548043/files/1511-03209.tar.gz"
 
 [GAP_pkg_modulargroup]
-git-tree-sha1 = "082e93d379c6ece43135c7993aebc4a0f23650b8"
+git-tree-sha1 = "628feb5f3540478607f58909deeb7617797a4ede"
 
     [[GAP_pkg_modulargroup.download]]
-    sha256 = "ee926e9bd61fb56a0ffc85051e4d8c4095eff5369f20d8f3e55fbf900bc04974"
-    url = "https://github.com/AG-Weitze-Schmithusen/ModularGroup/releases/download/v2.0.0/ModularGroup-2.0.0.tar.gz"
+    sha256 = "66f00a41d32f060784d0d88ec2ba2c245b94c7be18fefdb95438a9309c974645"
+    url = "https://github.com/AG-Weitze-Schmithusen/ModularGroup/releases/download/v2.0.1/ModularGroup-2.0.1.tar.gz"
 
 [GAP_pkg_origami]
-git-tree-sha1 = "2daeee15e66d962f2c18317a89acbcf9d8de1ded"
+git-tree-sha1 = "923fa2f4d20779ef938afac43c10cb427d9b0232"
 
     [[GAP_pkg_origami.download]]
-    sha256 = "f7fadb3bd19015645c457deaabebc09f76e735ef584e1041bf632f27c04ee016"
-    url = "https://github.com/AG-Weitze-Schmithusen/Origami/releases/download/v2.0.1/Origami-2.0.1.tar.gz"
+    sha256 = "1494e4a3acd3c8caa9e97252a3a41480d5c1d4d39d5af025de4ee44959c5aa3c"
+    url = "https://github.com/AG-Weitze-Schmithusen/Origami/releases/download/v2.0.2/Origami-2.0.2.tar.gz"
 
 [QSMDB]
 git-tree-sha1 = "472148e587b9da2c78a9955d0d258fbbfed649de"

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -6,6 +6,20 @@ lazy = true
     sha256 = "9c2f4f6fa9cab3df70cbb2511e1caf4d8d5c8ddb27f8c3b4ddba1f1b84dc8848"
     url = "https://zenodo.org/records/15548043/files/1511-03209.tar.gz"
 
+[GAP_pkg_modulargroup]
+git-tree-sha1 = "082e93d379c6ece43135c7993aebc4a0f23650b8"
+
+    [[GAP_pkg_modulargroup.download]]
+    sha256 = "ee926e9bd61fb56a0ffc85051e4d8c4095eff5369f20d8f3e55fbf900bc04974"
+    url = "https://github.com/AG-Weitze-Schmithusen/ModularGroup/releases/download/v2.0.0/ModularGroup-2.0.0.tar.gz"
+
+[GAP_pkg_origami]
+git-tree-sha1 = "2daeee15e66d962f2c18317a89acbcf9d8de1ded"
+
+    [[GAP_pkg_origami.download]]
+    sha256 = "f7fadb3bd19015645c457deaabebc09f76e735ef584e1041bf632f27c04ee016"
+    url = "https://github.com/AG-Weitze-Schmithusen/Origami/releases/download/v2.0.1/Origami-2.0.1.tar.gz"
+
 [QSMDB]
 git-tree-sha1 = "472148e587b9da2c78a9955d0d258fbbfed649de"
 lazy = true

--- a/etc/add_GAP_pkg_artifact.jl
+++ b/etc/add_GAP_pkg_artifact.jl
@@ -1,0 +1,45 @@
+#
+# This script is used to update Artifacts.toml.
+# Any changes to unrelated parts of Artifacts.toml (like comments) *should be reverted* after running this script.
+#
+# Usage variants:
+#   julia --project=etc etc/add_GAP_pkg_artifact.jl name https://github.com/.../releases/download/.../....tar.gz
+#
+
+using Downloads: download
+import Pkg
+using Pkg.Artifacts
+import TOML
+import SHA
+
+function sha256sum(tarball_path)
+    return open(tarball_path, "r") do io
+        return bytes2hex(SHA.sha256(io))
+    end
+end
+
+function add_artifact_for_package(pkgname::String, pkgurl::String, artifact_toml = joinpath(@__DIR__, "..", "Artifacts.toml"))
+  pkg_artifact_name = "GAP_pkg_$(lowercase(pkgname))"
+  
+  tarball_path = download(pkgurl)
+  tarball_hash = sha256sum(tarball_path)
+  
+  pkg_artifact_hash = create_artifact() do artifact_dir
+      Pkg.PlatformEngines.unpack(tarball_path, artifact_dir)
+  end
+
+  rm(tarball_path)
+
+  bind_artifact!(
+    artifact_toml,
+    pkg_artifact_name,
+    pkg_artifact_hash;
+    download_info=[(pkgurl, tarball_hash)],
+    force=true,
+  )
+end
+
+@assert length(ARGS) == 2
+pkgname = ARGS[1]
+pkgurl = ARGS[2]
+add_artifact_for_package(pkgname, pkgurl)

--- a/experimental/Origami/src/Origami.jl
+++ b/experimental/Origami/src/Origami.jl
@@ -5,14 +5,12 @@ module OrigamiHelper
 using ..Oscar
 using LazyArtifacts
 
-# this is not an __init__ function because we want it to run after the __init__ of Oscar
-# (and __init__ functions of submodules are run before the __init__ of the parent module)
-function __init_Origami()
+function __init__()
   GAP.Globals.ExtendPackageDirectories(GapObj([
     abspath(artifact"GAP_pkg_modulargroup"),
     abspath(artifact"GAP_pkg_origami")
   ]; recursive = true))
-  GAP.Packages.load("Origami")
+  # the packages get loaded in Oscar.__init__()
 end
 
 end

--- a/experimental/Origami/src/Origami.jl
+++ b/experimental/Origami/src/Origami.jl
@@ -2,15 +2,16 @@
 
 module OrigamiHelper
 
-using ..GAP
+using ..Oscar
+using LazyArtifacts
 
 # this is not an __init__ function because we want it to run after the __init__ of Oscar
 # (and __init__ functions of submodules are run before the __init__ of the parent module)
 function __init_Origami()
-  mod_p = "https://ag-weitze-schmithusen.github.io/ModularGroup/PackageInfo.g"
-  ori_p = "https://ag-weitze-schmithusen.github.io/Origami/PackageInfo.g"
-  GAP.Packages.install(mod_p)
-  GAP.Packages.install(ori_p)
+  GAP.Globals.ExtendPackageDirectories(GapObj([
+    abspath(artifact"GAP_pkg_modulargroup"),
+    abspath(artifact"GAP_pkg_origami")
+  ]; recursive = true))
   GAP.Packages.load("Origami")
 end
 

--- a/experimental/Origami/src/Origami.jl
+++ b/experimental/Origami/src/Origami.jl
@@ -4,7 +4,9 @@ module OrigamiHelper
 
 using ..GAP
 
-function __init__()
+# this is not an __init__ function because we want it to run after the __init__ of Oscar
+# (and __init__ functions of submodules are run before the __init__ of the parent module)
+function __init_Origami()
   mod_p = "https://ag-weitze-schmithusen.github.io/ModularGroup/PackageInfo.g"
   ori_p = "https://ag-weitze-schmithusen.github.io/Origami/PackageInfo.g"
   GAP.Packages.install(mod_p)

--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -107,6 +107,7 @@ function __init__()
      "ferret",   # backtrack in permutation groups
      "fga",      # dealing with free groups
      "forms",    # bilinear/sesquilinear/quadratic forms
+     "origami",  # for experimental/Origami
      "packagemanager", # has been loaded already by GAP.jl
      "polycyclic", # needed for Oscar's pc groups
      "primgrp",  # primitive groups library
@@ -123,7 +124,6 @@ function __init__()
   # also those that are triggered from GAP packages.
   __GAP_info_messages_off()
   __init_group_libraries()
-  OrigamiHelper.__init_Origami()
 
   add_verbosity_scope(:K3Auto)
   add_assertion_scope(:K3Auto)

--- a/src/Oscar.jl
+++ b/src/Oscar.jl
@@ -123,6 +123,7 @@ function __init__()
   # also those that are triggered from GAP packages.
   __GAP_info_messages_off()
   __init_group_libraries()
+  OrigamiHelper.__init_Origami()
 
   add_verbosity_scope(:K3Auto)
   add_assertion_scope(:K3Auto)


### PR DESCRIPTION
This adresses https://github.com/oscar-system/Oscar.jl/pull/5345#discussion_r2366375987 in the way how we handle installation of deposited GAP packages inside of GAP.jl.

Additionally, this addresses a part of the issues mentioned in the CI logs of https://github.com/oscar-system/Oscar.jl/pull/5345, namely (https://github.com/oscar-system/Oscar.jl/actions/runs/19213809957/job/54920128504?pr=5345#step:10:340)
```
      From worker 4:	#I  Package already installed at target location
      From worker 4:	#I  Target directory /home/oscarci-tester/ssd-data/ssd-runner-04/julia/scratchspaces/c863536a-3901-11e9-33e7-d5cd0df7b904/gap_packagedir_v4.15/pkg/Origami-2.0.1 exists and is non-empty
      From worker 4:	#I  Appending '.old' to old version directory
      From worker 4:	#I  Possible error detected, see log:
      From worker 4:	#I    /usr/bin/mv: cannot move '/home/oscarci-tester/ssd-data/ssd-runner-04/julia/scratchspaces/c863536a-3901-11e9-33e7-d5cd0df7b904/gap_packagedir_v4.15/pkg/Origami-2.0.1' to '/home/oscarci-tester/ssd-data/ssd-runner-04/julia/scratchspaces/c863536a-3901-11e9-33e7-d5cd0df7b904/gap_packagedir_v4.15/pkg/Origami-2.0.1.old/Origami-2.0.1': Directory not empty
      From worker 4:	#I  Could not rename old package directory
```
Note: there are more issues mentioned in this log, I commented about them at https://github.com/oscar-system/Oscar.jl/pull/5345#pullrequestreview-3448208312.

@Sebas777-gif please wait with merging this until @fingolfin and/or @ThomasBreuer had a chance to look at this.